### PR TITLE
In hamlib 4.2 the FILPATHLEN was replaced by HAMLIB_FILPATHLEN

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,9 @@
+Release 0.1.2 (pending)
+==========================
+
+- Fix build for Hamlib 4.2 and up
+- Fix hamlib control for Softrock
+
 Release 0.1.1 (2019-05-12)
 ==========================
 

--- a/RigThread.cpp
+++ b/RigThread.cpp
@@ -44,7 +44,11 @@ void RigThread::run() {
         return;
     }
 
-	strncpy(rig->state.rigport.pathname, rigFile.c_str(), FILPATHLEN - 1);
+    //provide HAMLIB_FILPATHLEN when building against Hamlib < 4.2
+    #ifndef HAMLIB_FILPATHLEN
+    #define HAMLIB_FILPATHLEN FILPATHLEN
+    #endif
+	strncpy(rig->state.rigport.pathname, rigFile.c_str(), HAMLIB_FILPATHLEN - 1);
     if (serialRate > 0)  // bypass for rate 0 used for USB controlled radios
 	    rig->state.rigport.parm.serial.rate = serialRate;
 


### PR DESCRIPTION
* closes https://github.com/pothosware/SoapyAudio/issues/18